### PR TITLE
fix: Remove unexpected keyword argument in FaceRestoreHelper

### DIFF
--- a/rp_handler.py
+++ b/rp_handler.py
@@ -139,7 +139,6 @@ def initialize_models():
         det_model='retinaface_resnet50', # or 'retinaface_mobile0.25'
         save_ext='png',
         use_parse=True, # Enable parsing for segmentation
-        det_threshold=0.5,
         align_mode='cv2_affine_align', # Default from KEEP
         device=device,
         model_rootpath=MODEL_BASE_PATH # Base for dlib and parsing models


### PR DESCRIPTION
Corrected a TypeError that occurred during `FaceRestoreHelper` initialization in `rp_handler.py`. The argument `det_threshold` was removed from the constructor call as it's not accepted by the version of FaceRestoreHelper in the `facelib` library.

This resolves the `TypeError: FaceRestoreHelper.__init__() got an unexpected keyword argument 'det_threshold'` error encountered during the Docker build process.