### PR TITLE
fix: Remove unexpected model_rootpath argument in FaceRestoreHelper

### DIFF
--- a/rp_handler.py
+++ b/rp_handler.py
@@ -139,8 +139,7 @@ def initialize_models():
         det_model='retinaface_resnet50', # or 'retinaface_mobile0.25'
         save_ext='png',
         use_parse=True, # Enable parsing for segmentation
-        device=device,
-        model_rootpath=MODEL_BASE_PATH # Base for dlib and parsing models
+        device=device
     )
     # Manually set the landmark predictor path for face_helper if necessary
     # face_helper.face_parse.landmark_predictor.predictor = dlib.shape_predictor(dlib_model_path)


### PR DESCRIPTION
Corrected a TypeError that occurred during `FaceRestoreHelper` initialization in `rp_handler.py`. The argument `model_rootpath` was removed from the constructor call as it is not accepted by the version of FaceRestoreHelper in the `facelib` library.

This resolves the `TypeError: FaceRestoreHelper.__init__() got an unexpected keyword argument 'model_rootpath'` error encountered during the Docker build process.