### PR TITLE
fix: Update KEEP model URL to GitHub release

### DIFF
--- a/rp_handler.py
+++ b/rp_handler.py
@@ -47,7 +47,7 @@ model_configs = {
     },
     'KEEP': { # KEEP model
         'model_path': os.path.join(MODEL_BASE_PATH, 'KEEP', 'KEEP-b76feb75.pth'), # Actual path in Docker
-        'model_url': 'https://huggingface.co/DongSky/KEEP/resolve/main/KEEP-b76feb75.pth' # Fallback
+        'model_url': 'https://github.com/jnjaby/KEEP/releases/download/v1.0.0/KEEP-b76feb75.pth'
     }
 }
 


### PR DESCRIPTION
I changed the download URL for the KEEP model in `rp_handler.py` from a Hugging Face direct link to the official GitHub release URL. This is to resolve an `HTTP Error 401: Unauthorized` encountered during model download in the Docker build process.

The new URL is `https://github.com/jnjaby/KEEP/releases/download/v1.0.0/KEEP-b76feb75.pth`.